### PR TITLE
Use fstream-npm to give npm style packages

### DIFF
--- a/lib/local.js
+++ b/lib/local.js
@@ -3,6 +3,7 @@ var path = require('path')
 
 var readJson = require("read-package-json")
 var mkdir = require('mkdirp')
+var fstream = require('fstream-npm')
 var pack = require('tar-pack').pack
 
 var github = require('./github')
@@ -31,7 +32,7 @@ function dir(src, dest, options, cb) {
 
     mkdir(path.dirname(dest), function (err) {
       if (err) return cb(err)
-      pack(src, dest, options, cb)
+      pack(fstream(src), dest, options, cb)
     })
   })
 }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "sha": "~1.0.1",
     "read-package-json": "~0.4.1",
     "tar-pack": "~1.0.0",
-    "fetch-file": "~1.0.1"
+    "fetch-file": "~1.0.1",
+    "fstream-npm": "~0.1.4"
   }
 }


### PR DESCRIPTION
The downside of this API is it makes it very specific to npm, it would be nice to just do this via options in some way.  Perhaps tar-pack could be improved?
