### PR TITLE
Implement local.file

### DIFF
--- a/lib/local.js
+++ b/lib/local.js
@@ -18,8 +18,21 @@ function fetch(src, dest, options, cb) {
 
 fetch.file = file
 function file(src, dest, options, cb) {
-  throw new Error('local.file is not yet implemented')
-  //todo: implement file
+  var src = fs.createReadStream(src)
+  var dest = fs.createWriteStream(dest)
+  src.pipe(dest)
+  var erred = false
+  src.on('error', error)
+  dest.on('error', error)
+  dest.on('close', function () {
+    if (erred) return
+    cb()
+  })
+  function error(err) {
+    if (erred) return
+    erred = true
+    cb(err)
+  }
 }
 
 fetch.dir = dir


### PR DESCRIPTION
I think just a simple file copy should suffice.  The result won't always be a `.tgz` file, but it will always be something that `tar-pack` can read.
