### PR TITLE
Don't allow OSX DS_Store-files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ lib-cov
 *.pid
 *.gz
 
+.DS_Store
+
 pids
 logs
 results


### PR DESCRIPTION
I am OSX user, these files are pretty annoying (and useless)
