### PR TITLE
use tar-pack with streams, fix failing tests

### DIFF
--- a/lib/local.js
+++ b/lib/local.js
@@ -48,7 +48,19 @@ function dir(src, dest, options, cb) {
 
     mkdir(path.dirname(dest), function (err) {
       if (err) return cb(err)
-      pack(fstream(src), dest, options, cb)
+      var destStream = fs.createWriteStream(dest);
+      var erred = false
+      destStream.on('error', error)
+      destStream.on('close', function () {
+        if (erred) return
+        cb()
+      })
+      pack(fstream(src), options).pipe(destStream)
+      function error(err) {
+        if (erred) return
+        erred = true
+        cb(err)
+      }
     })
   })
 }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "mkdirp": "~0.3.5",
     "sha": "~1.0.1",
     "read-package-json": "~0.4.1",
-    "tar-pack": "~1.0.0",
+    "tar-pack": "~2.0.0",
     "fetch-file": "~1.0.1",
     "fstream-npm": "~0.1.4"
   },


### PR DESCRIPTION
I switched to the latest `tar-pack` and made the tests green again
