### PR TITLE
add full git support

### DIFF
--- a/lib/git.js
+++ b/lib/git.js
@@ -1,64 +1,75 @@
 'use strict'
-var exec = require("child_process").execFile
-var spawn = require("child_process").spawn
+
+var exec = require('child_process').execFile
+var spawn = require('child_process').spawn
 var zlib = require('zlib')
 var path = require('path')
 var url = require('url')
 var fs = require('fs')
+var os = require('os')
 
 var PassThrough = require('barrage').PassThrough
-var mkdirp = require('mkdirp')
-var rimraf = require('rimraf')
+var discern = require('discern')
+var temp = require('temp')
+
+var github = require('./github.js')
 
 var env = gitEnv()
 
-module.exports = function (name, spec, options) {
-  var git_url = spec.replace(/^git\+/, "").replace(/#.*$/, "")
-  var parsed = url.parse(spec)
-  var co = parsed.hash && parsed.hash.substr(1) || "master"
+temp.track()
 
-  var result = new PassThrough
+module.exports = function (name, spec, options) {
+  if (discern.isGitHubUrl(spec)) {
+    var res = discern.github(spec)
+    spec = res[0] + '/' + res[1] + '#' + res[2]
+    return github(name, spec, options)
+  }
+
+  var gitUrl = spec.replace(/^git\+/, '').replace(/#.*$/, '')
+  var parsed = url.parse(spec)
+  var co = parsed.hash && parsed.hash.substr(1) || 'master'
+
+  var result = new PassThrough().on('end', function () {
+    temp.cleanupSync()
+  })
 
   options = options || {}
 
-  if(parsed.pathname.match(/^\/?:/)) {
-    git_url = git_url.replace(/^ssh:\/\//, "")
+  if (parsed.pathname.match(/^\/?:/)) {
+    gitUrl = gitUrl.replace(/^ssh:\/\//, '')
   }
 
-  var dir = path.join(
-      options.tempDir || process.cwd()
-    , 'temp-' + git_url.replace(/[^a-zA-Z0-9]+/g, '-')
-  )
+  var dirOptions = {dir: options.tempdir || path.join(os.tmpdir(),'npm-fetch')}
 
-  try {
-    rimraf.sync(dir)
-    mkdirp.sync(dir)
-  } catch(err) {
-    return reject(err)
-  }
-
-  clone(dir, git_url, co, function(err, stream) {
-    if(!err) {
-      return stream.on('end', result.end.bind(result)).syphon(result)
+  temp.mkdir(dirOptions, function (err, dir) {
+    if(err) {
+      onError(err)
     }
 
-    result.emit('error', err)
-    result.end()
+    clone(dir, gitUrl, co, function (err, stream) {
+      if (!err) {
+        return stream.on('end', result.end.bind(result)).syphon(result)
+      }
+
+      onError(err)
+    })
   })
 
-  result.on('end', function() {
+  function onError(err) {
     try {
-      rimraf.sync(dir)
-    } catch(err) {}
-  })
+      temp.cleanupSync()
+    } catch (err) {}
+    result.emit('error', err)
+    result.end()
+  }
 
   return result
 }
 
-function clone(dir, gitUrl, co, cb) {
-  var args = [ "clone", "--mirror", gitUrl, dir]
+function clone (dir, gitUrl, co, cb) {
+  var args = [ 'clone', '--mirror', gitUrl, dir]
 
-  exec('git', args, {cwd: dir, env: env}, function(err) {
+  exec(options.git || 'git', args, {cwd: dir, env: env}, function (err) {
     if (err) {
       return cb(err)
     }
@@ -67,19 +78,19 @@ function clone(dir, gitUrl, co, cb) {
   })
 }
 
-function getTarball(dir, co, cb) {
-  var args = ["archive", co, "--format=tar", "--prefix=package/"]
-  var child = spawn('git', args, { env: env, cwd: dir })
+function getTarball (dir, co, cb) {
+  var args = ['archive', co, '--format=tar', '--prefix=package/']
+  var child = spawn(options.git || 'git', args, { env: env, cwd: dir })
   var out = new PassThrough
 
-  child.on("error", out.emit.bind(out, "error"))
+  child.on('error', out.emit.bind(out, 'error'))
   child.stdout.pipe(zlib.createGzip()).pipe(out)
 
   cb(null, out)
 }
 
 function gitEnv() {
-  var whiteList = ["GIT_PROXY_COMMAND", "GIT_SSH", "GIT_SSL_NO_VERIFY"]
+  var whiteList = ['GIT_PROXY_COMMAND', 'GIT_SSH', 'GIT_SSL_NO_VERIFY']
   var env = {}
 
   for (var k in process.env) {

--- a/package.json
+++ b/package.json
@@ -21,11 +21,12 @@
     "barrage": "~1.0.0",
     "discern": "~1.1.0",
     "npm-registry-client": "~0.3.3",
-    "mkdirp": "^0.5.0",
-    "rimraf": "^2.2.8"
+    "temp": "^0.8.0"
   },
   "devDependencies": {
     "mocha": "~1.9",
+    "mkdirp": "^0.5.0",
+    "rimraf": "^2.2.8",
     "npmconf": "*",
     "npm-registry-mock": "*",
     "strong-caching-http-client": "git+https://github.com/strongloop/strong-caching-http-client.git"


### PR DESCRIPTION
I think this is is fairly functional, 90% of use cases were already supported with the github logic.  for the remaining cases shelling out to git and using a a temp directory to store the repo seems like a reasonable way to go.  as long as the process does not crash files will be cleaned up as soon as they are not needed, and by default are stored in the os's temp dir.  
